### PR TITLE
initial support for farbwerk temperature sensors

### DIFF
--- a/FanControl.AquacomputerDevices/DataStructs/Farbwerk.cs
+++ b/FanControl.AquacomputerDevices/DataStructs/Farbwerk.cs
@@ -1,0 +1,309 @@
+﻿using AquacomputerStructs.Helpers;
+using HidLibrary;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AquacomputerStructs.Devices.Farbwerk
+{
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct device_status
+    {
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U4)]
+        public uint system_state;
+
+        public byte feature_unlock;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U4)]
+        public uint time;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U4)]
+        public uint power_up_cnt;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U4)]
+        public uint runtime_total;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct sensor_data
+    {
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 9)]
+        public ushort[] adc_raw;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+        public short[] temperatures;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public short[] sensors;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public byte[] sensors_units;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short vcc12;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short flow;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U4)]
+        public uint alarm_state;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U4)]
+        public uint alarm_state_last;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1)]
+        public short[] strip_power;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1)]
+        public short[] strip_power_scale;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1)]
+        public byte[] strip_scale;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U2)]
+        public ushort strip_state;
+
+        public byte profileId;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct Sensor
+    {
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short offset;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct PidInfo
+    {
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short setpoint;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short p;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short i;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short d;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short d_tn;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short hysteresis;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U2)]
+        public ushort flags;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct CurveInfo
+    {
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short start_value;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public short[] input;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public short[] output;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct Controller
+    {
+        public byte mode;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short power;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short source;
+
+        public PidInfo pid;
+
+        public CurveInfo curve;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct StripConfigInfo
+    {
+        public byte brightness;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U2)]
+        public ushort flags;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct LedControllerSrcInfo
+    {
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short id;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
+        public byte[] filter;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct LedControllerBindingInfo
+    {
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short x1;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short x2;
+
+        public byte y1;
+
+        public byte y2;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct HsvColor
+    {
+        public const int MAX_HUE = 1535;
+        public const int COLOR_RED = 0;
+        public const int COLOR_ORANGE = 128;
+        public const int COLOR_YELLOW = 256;
+        public const int COLOR_GREEN = 512;
+        public const int COLOR_AQUA = 768;
+        public const int COLOR_BLUE = 1024;
+        public const int COLOR_PURPLE = 1280;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U2)]
+        public ushort h;
+        public byte s;
+        public byte v;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct LedControllerInfo
+    {
+        public byte strip;
+
+        public byte led_start;
+
+        public byte count;
+
+        public byte mode;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U2)]
+        public ushort flags;
+
+        public LedControllerSrcInfo src;
+
+        public LedControllerBindingInfo binding1;
+
+        public LedControllerBindingInfo binding2;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 12)]
+        public short[] values;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
+        public HsvColor[] hsv;
+    }
+
+    /// <summary>
+    /// Report Id = 3 (append 2 byte crc after this struct)
+    /// </summary>
+    /// 
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct Settings
+    {
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U2)]
+        public ushort structure_id;
+
+        public byte i2c_address;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U2)]
+        public ushort flags;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public ushort flow_calibration;
+
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.I2)]
+        public short flow_factor;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+        public Sensor[] sensor;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+        public Controller[] controller;
+
+        public StripConfigInfo strip_config;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
+        public LedControllerInfo[] led_controller;
+
+        public byte profileId;
+
+        public byte dummy;
+    }
+
+    /// 
+    /// Report Id 8 (FeatureData) 
+    /// 
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct ProfileName
+    {
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 24)]
+        public byte[] name;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct Profile
+    {
+        [Endian(Endianness.BigEndian)]
+        [MarshalAs(UnmanagedType.U2)]
+        public ushort version_id;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 42)]
+        public ProfileName[] names;
+    }
+}

--- a/FanControl.AquacomputerDevices/Devices/DevicesHelpers.cs
+++ b/FanControl.AquacomputerDevices/Devices/DevicesHelpers.cs
@@ -16,6 +16,7 @@ namespace FanControl.AquacomputerDevices.Devices
             yield return new HighFlowNextDevice();
             yield return new QuadroDevice();
             yield return new OctoDevice();
+            yield return new FarbwerkDevice();
         }
 
         public static IEnumerable<int> GetSupportedProductIds()

--- a/FanControl.AquacomputerDevices/Devices/FarbwerkDevice.cs
+++ b/FanControl.AquacomputerDevices/Devices/FarbwerkDevice.cs
@@ -1,0 +1,124 @@
+﻿using AquacomputerStructs.Helpers;
+using FanControl.Plugins;
+using HidLibrary;
+using System;
+using System.Linq;
+using System.Threading;
+
+namespace FanControl.AquacomputerDevices.Devices
+{
+    internal class FarbwerkDevice : IAquacomputerDevice
+    {
+        private HidLibrary.HidDevice hidDevice = null;
+        private IPluginLogger _logger;
+        private AquacomputerStructs.Devices.Farbwerk.Settings? initial_settings = null;
+        private AquacomputerStructs.Devices.Farbwerk.Settings? current_settings = null;
+        private AquacomputerStructs.Devices.Farbwerk.sensor_data sensor_data;
+        private DateTime last_settings_read = DateTime.MinValue;
+        private readonly TimeSpan settings_timeout = new TimeSpan(0, 5, 0); // every 5 minutes
+
+        public int GetProductId() => 0xF010;
+        public string GetDevicePath() => hidDevice?.DevicePath;
+
+        public IAquacomputerDevice AssignDevice(HidDevice device, IPluginLogger logger)
+        {
+            _logger = logger;
+            _logger.Log($"FarbwerkDevice.AssignDevice(device: {device}, logger: {logger})");
+            if (hidDevice == null)
+            {
+                hidDevice = device;
+
+                hidDevice.OpenDevice();
+                Update();
+            }
+            return this;
+        }
+
+        public void Load(IPluginSensorsContainer _container, int index = 0)
+        {
+            _logger.Log($"FarbwerkDevice.Load(_container: {_container}, index = {index})");
+            if (hidDevice == null)
+                return;
+
+            // Value for this sensor should be checked!
+            _container.FanSensors.Add(new DeviceBaseSensor<AquacomputerStructs.Devices.Farbwerk.sensor_data>("FarbwerkDevice"+index+".Flow", "Farbwerk "+index+" Flow Sensor", () => this.Data_GetTemperature(() => this.sensor_data.flow)));
+
+            _container.TempSensors.Add(new DeviceBaseSensor<AquacomputerStructs.Devices.Farbwerk.sensor_data>("FarbwerkDevice"+index+".Temp0", "Farbwerk "+index+" Temperature 1", () => this.Data_GetTemperature(() => this.sensor_data.temperatures[0])));
+            _container.TempSensors.Add(new DeviceBaseSensor<AquacomputerStructs.Devices.Farbwerk.sensor_data>("FarbwerkDevice"+index+".Temp1", "Farbwerk "+index+" Temperature 2", () => this.Data_GetTemperature(() => this.sensor_data.temperatures[1])));
+            _container.TempSensors.Add(new DeviceBaseSensor<AquacomputerStructs.Devices.Farbwerk.sensor_data>("FarbwerkDevice"+index+".Temp2", "Farbwerk "+index+" Temperature 3", () => this.Data_GetTemperature(() => this.sensor_data.temperatures[2])));
+            _container.TempSensors.Add(new DeviceBaseSensor<AquacomputerStructs.Devices.Farbwerk.sensor_data>("FarbwerkDevice"+index+".Temp3", "Farbwerk "+index+" Temperature 4", () => this.Data_GetTemperature(() => this.sensor_data.temperatures[3])));
+        }
+
+        public void Unload()
+        {
+            _logger.Log($"FarbwerkDevice.Unload()");
+            hidDevice?.CloseDevice();
+            hidDevice = null;
+        }
+
+        public void Update()
+        {
+            //_logger.Log($"FarbwerkDevice.Update() (hidDevice: {hidDevice}, is open: {hidDevice.IsOpen}");
+            if (hidDevice == null)
+                return;
+
+            var deviceData = hidDevice.Read(500);
+
+            if (deviceData != null && deviceData.Status == HidDeviceData.ReadStatus.Success)
+            {
+                int offset = 0;
+                EndianAttribute.GetStructAtOffset<AquacomputerStructs.Common.device_header>(deviceData.Data, ref offset);
+                EndianAttribute.GetStructAtOffset<AquacomputerStructs.Devices.Farbwerk.device_status>(deviceData.Data, ref offset);
+                sensor_data = EndianAttribute.GetStructAtOffset<AquacomputerStructs.Devices.Farbwerk.sensor_data>(deviceData.Data, ref offset);
+            }
+
+            Settings_UpdateSettings();
+        }
+
+        private float? Data_GetTemperature(Func<short> temp, float ratio = 100.0f)
+        {
+            if (hidDevice == null)
+                return null;
+            try
+            {
+                short val = temp();
+                if (val == short.MaxValue)
+                    return 0;
+
+                return val / ratio;
+            }
+            catch (ApplicationException e)
+            {
+                _logger.Log("Data_GetReadLockLambda() ApplicationException: " + e);
+            }
+            return null;
+        }
+
+        private bool Settings_UpdateSettings(bool force = false)
+        {
+            //_logger.Log($"FarbwerkDevice.Settings_UpdateSettings()");
+            int offset = 1;
+
+            if (this.current_settings != null && !force &&
+                this.last_settings_read + this.settings_timeout >= DateTime.Now)
+                return true;
+
+            // Read current settings
+            if (hidDevice.ReadFeatureData(out byte[] data, 3))
+            {
+                this.current_settings = EndianAttribute.GetStructAtOffset<AquacomputerStructs.Devices.Farbwerk.Settings>(data, ref offset);
+                if (this.initial_settings == null)
+                    this.initial_settings = current_settings;
+
+                this.last_settings_read = DateTime.Now;
+                return true;
+            } 
+            else
+            {
+                _logger.Log("FarbwerkDevice: Failed to read settings from device.");
+                //Debugger.Launch();
+                return false;
+            }
+        }
+    }
+}

--- a/FanControl.AquacomputerDevices/FanControl.AquacomputerDevices.csproj
+++ b/FanControl.AquacomputerDevices/FanControl.AquacomputerDevices.csproj
@@ -54,12 +54,14 @@
     <Compile Include="Devices\OctoDevice.cs" />
     <Compile Include="Devices\QuadroDevice.cs" />
     <Compile Include="Devices\HighFlowNextDevice.cs" />
+	<Compile Include="Devices\FarbwerkDevice.cs" />
     <Compile Include="CrcDotNet\CrcBase.cs" />
     <Compile Include="CrcDotNet\CrcConfigurationException.cs" />
     <Compile Include="CrcDotNet\CrcParameters.cs" />
     <Compile Include="DataStructs\Common.cs" />
     <Compile Include="DataStructs\HighFlowNext.cs" />
     <Compile Include="DataStructs\Quadro.cs" />
+	<Compile Include="DataStructs\Farbwerk.cs" />
     <Compile Include="Endianess.cs" />
     <Compile Include="Devices\IAquacomputerDevice.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This pull request provides initial (read: incomplete/experimental) support for the Aquacomputer Farbwerk 360. It was tested on firmware 1025 with 4 temperatures sensors attached. Unknown if the flow sensor or 4x RGB controllers work.

The Farbwerk.cs and FarbwerkDevice.cs files were copied and modified from the Quadro files.

I've also attached a Wireshark capture of the device that was used to get offsets for the temperatures and may be useful for other information.

[farbwerk_capture.zip](https://github.com/medevil84/FanControl.AquacomputerDevices/files/14548403/farbwerk_capture.zip)
