### PR TITLE
Fix HID stream buffering

### DIFF
--- a/FanControl.AquacomputerDevices/Devices/CachedHidStream.cs
+++ b/FanControl.AquacomputerDevices/Devices/CachedHidStream.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.Ports;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FanControl.Plugins;
+
+namespace FanControl.AquacomputerDevices.Devices
+{
+    internal class CachedHidStream : IDisposable
+    {
+        private HidSharp.HidStream hidStream;
+
+        private CancellationTokenSource cancelTokenSource;
+        private bool canRead = false;
+        private byte[] cachedValue = null;
+        private Exception exception = null;
+
+        public CachedHidStream(HidSharp.HidStream stream)
+        {
+            hidStream = stream;
+            cancelTokenSource = new CancellationTokenSource();
+            var cancelToken = cancelTokenSource.Token;
+
+            ReadOnce();
+            new Thread(() =>
+            {
+                stream.ReadTimeout = Timeout.Infinite;
+
+                try
+                {
+                    while (!cancelToken.IsCancellationRequested)
+                    {
+                        ReadOnce();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+
+                canRead = false;
+            }).Start();
+        }
+
+        private void ReadOnce()
+        {
+            var result = hidStream.Read();
+            if (result != null)
+            {
+                lock (this)
+                {
+                    canRead = true;
+                    cachedValue = result;
+                }
+            }
+        }
+
+        public void Close()
+        {
+            cancelTokenSource.Cancel();
+            hidStream.Close();
+        }
+
+        public virtual void Dispose()
+        {
+            Close();
+        }
+
+        private bool GetCanRead()
+        {
+            lock (this)
+            {
+                return canRead;
+            }
+        }
+
+        public bool CanRead
+        {
+            get => GetCanRead();
+        }
+
+        public byte[] Read()
+        {
+            lock (this)
+            {
+                if (exception != null)
+                {
+                    throw exception;
+                }
+                return cachedValue;
+            }
+        }
+
+        public void GetFeature(byte[] buffer)
+        {
+            hidStream.GetFeature(buffer);
+        }
+
+        public void SetFeature(byte[] buffer)
+        {
+            hidStream.SetFeature(buffer);
+        }
+
+        public void Write(byte[] buffer)
+        {
+            hidStream.Write(buffer);
+        }
+    }
+}

--- a/FanControl.AquacomputerDevices/Devices/FarbwerkDevice.cs
+++ b/FanControl.AquacomputerDevices/Devices/FarbwerkDevice.cs
@@ -10,7 +10,7 @@ namespace FanControl.AquacomputerDevices.Devices
     internal class FarbwerkDevice : IAquacomputerDevice
     {
         private HidSharp.HidDevice hidDevice = null;
-        private HidSharp.HidStream hidStream = null;
+        private CachedHidStream hidStream = null;
         private IPluginLogger _logger;
         private AquacomputerStructs.Devices.Farbwerk.Settings? initial_settings = null;
         private AquacomputerStructs.Devices.Farbwerk.Settings? current_settings = null;
@@ -28,7 +28,7 @@ namespace FanControl.AquacomputerDevices.Devices
             if (hidDevice == null)
             {
                 hidDevice = device;
-                hidStream = hidDevice.Open();
+                hidStream = new CachedHidStream(hidDevice.Open());
 
                 Update();
             }

--- a/FanControl.AquacomputerDevices/Devices/HighFlowNextDevice.cs
+++ b/FanControl.AquacomputerDevices/Devices/HighFlowNextDevice.cs
@@ -7,7 +7,7 @@ namespace FanControl.AquacomputerDevices.Devices
     internal class HighFlowNextDevice : IAquacomputerDevice
     {
         private HidSharp.HidDevice hidDevice = null;
-        private HidSharp.HidStream hidStream = null;
+        private CachedHidStream hidStream = null;
         private IPluginLogger _logger;
         private AquacomputerStructs.Devices.HighFlowNext.sensor_data sensor_data;
 
@@ -22,7 +22,7 @@ namespace FanControl.AquacomputerDevices.Devices
             if (hidDevice == null)
             {
                 hidDevice = device;
-                hidStream = hidDevice.Open();
+                hidStream = new CachedHidStream(hidDevice.Open());
 
                 Update();
             }

--- a/FanControl.AquacomputerDevices/Devices/OctoDevice.cs
+++ b/FanControl.AquacomputerDevices/Devices/OctoDevice.cs
@@ -12,7 +12,7 @@ namespace FanControl.AquacomputerDevices.Devices
     internal class OctoDevice : IAquacomputerDevice
     {
         private HidSharp.HidDevice hidDevice = null;
-        private HidSharp.HidStream hidStream = null;
+        private CachedHidStream hidStream = null;
         private IPluginLogger _logger;
         private AquacomputerStructs.Devices.Octo.Settings? initial_settings = null;
         private AquacomputerStructs.Devices.Octo.Settings? current_settings = null;
@@ -30,7 +30,7 @@ namespace FanControl.AquacomputerDevices.Devices
             if (hidDevice == null)
             {
                 hidDevice = device;
-                hidStream = hidDevice.Open();
+                hidStream = new CachedHidStream(hidDevice.Open());
 
                 Update();
             }

--- a/FanControl.AquacomputerDevices/Devices/QuadroDevice.cs
+++ b/FanControl.AquacomputerDevices/Devices/QuadroDevice.cs
@@ -9,7 +9,7 @@ namespace FanControl.AquacomputerDevices.Devices
     internal class QuadroDevice : IAquacomputerDevice
     {
         private HidSharp.HidDevice hidDevice = null;
-        private HidSharp.HidStream hidStream = null;
+        private CachedHidStream hidStream = null;
         private IPluginLogger _logger;
         private AquacomputerStructs.Devices.Quadro.Settings? initial_settings = null;
         private AquacomputerStructs.Devices.Quadro.Settings? current_settings = null;
@@ -27,7 +27,7 @@ namespace FanControl.AquacomputerDevices.Devices
             if (hidDevice == null)
             {
                 hidDevice = device;
-                hidStream = hidDevice.Open();
+                hidStream = new CachedHidStream(hidDevice.Open());
 
                 Update();
             }

--- a/FanControl.AquacomputerDevices/FanControl.AquacomputerDevices.csproj
+++ b/FanControl.AquacomputerDevices/FanControl.AquacomputerDevices.csproj
@@ -50,6 +50,7 @@
   <ItemGroup>
     <Compile Include="AquacomputerPlugin.cs" />
     <Compile Include="DataStructs\Octo.cs" />
+    <Compile Include="Devices\CachedHidStream.cs" />
     <Compile Include="Devices\DevicesHelpers.cs" />
     <Compile Include="Devices\OctoDevice.cs" />
     <Compile Include="Devices\QuadroDevice.cs" />


### PR DESCRIPTION
Unread HID reports get buffered until they're read, so if we fail to call Read as often as the device emits reports, we will accrue stale reports in the buffer and fall further and further behind. This can be seen when running CPU intensive tasks that starve Fan Control of cycles, or induced manually by using Resource Monitor to suspend the process.

Fix this by spawning a thread that spins on HidStream.Read to ensure that we're always emptying the HID stream's buffer.